### PR TITLE
Fixed a typo in Romania (Social Housing)

### DIFF
--- a/tax_rates.csv
+++ b/tax_rates.csv
@@ -62,7 +62,7 @@
 "Portugal (reduced: food)","PT","*","","13.0000","","","","",""
 "Portugal (reduced: food / books / pharma / medical / hotels)","PT","*","","6.0000","","","","",""
 "Romania (standard)","RO","*","","24.0000","","","","",""
-"Romania (reduced: social hosing)","RO","*","","5.0000","","","","",""
+"Romania (reduced: social housing)","RO","*","","5.0000","","","","",""
 "Romania (reduced: books / pharma / medical / hotels)","RO","*","","9.0000","","","","",""
 "Slovakia (standard)","SK","*","","20.0000","","","","",""
 "Slovakia (reduced: books / food / medical / pharma)","SK","*","","10.0000","","","","",""


### PR DESCRIPTION
The entry for 'Romania (Social Housing)' has a typo.