### PR TITLE
Update Estonian standard tax rate to 22%

### DIFF
--- a/tax_rates_eu.csv
+++ b/tax_rates_eu.csv
@@ -24,7 +24,7 @@
 "Czech Republic (zero: Intra-comm. and internat. transp.)","CZ","*","","0.0000","","","",""
 "Denmark (standard)","DK","*","","25.0000","","","",""
 "Denmark (zero: newspapers / Intra-comm. and internat. transp.)","DK","*","","0.0000","","","",""
-"Estonia (standard)","EE","*","","20.0000","","","",""
+"Estonia (standard)","EE","*","","22.0000","","","",""
 "Estonia (reduced: books / pharma / medical / hotels)","EE","*","","9.0000","","","",""
 "Estonia (zero: Intra-comm. and some passenger transp.)","EE","*","","0.0000","","","",""
 "Finland (standard)","FI","*","","24.0000","","","",""


### PR DESCRIPTION
With effect from January 1, 2024, the normal VAT rate has been increased from 20% to 22%. The two reduced rates of 5% and 9% remain applicable.

Source: https://trade.ec.europa.eu/access-to-markets/nl/news/wijzigingen-van-de-btw-tarieven-bepaalde-eu-lidstaten-die-van-toepassing-waren-op-1-januari-2024