### PR TITLE
Update tax_rates_eu.csv

### DIFF
--- a/tax_rates_eu.csv
+++ b/tax_rates_eu.csv
@@ -27,7 +27,7 @@
 "Estonia (standard)","EE","*","","22.0000","","","",""
 "Estonia (reduced: books / pharma / medical / hotels)","EE","*","","9.0000","","","",""
 "Estonia (zero: Intra-comm. and some passenger transp.)","EE","*","","0.0000","","","",""
-"Finland (standard)","FI","*","","24.0000","","","",""
+"Finland (standard)","FI","*","","25.5000","","","",""
 "Finland (reduced: restaurants)","FI","*","","14.0000","","","",""
 "Finland (reduced: books / pharma / hotels)","FI","*","","10.0000","","","",""
 "Finland (zero: Intra-comm. and internat. transp.)","FI","*","","0.0000","","","",""


### PR DESCRIPTION
Finland tax rate change from 24 to 25.5 percent, source: https://www.vatcalc.com/finland/finland-increases-vat-to-24-january-2013/